### PR TITLE
Assigning HVA to Azure resources using tags

### DIFF
--- a/fetch_subscription_resources.py
+++ b/fetch_subscription_resources.py
@@ -531,11 +531,9 @@ def iterate_resources_to_json(
                 json_key = "apiManagements"
             try:
                 hva_tag = tags["scad"]
-                class_name = json_key[0].upper() + json_key[1:-1]
                 hva_tags = hva_tagging.handle_hva_tag(
                     hva_tag=hva_tag,
                     resource_id=resource_id.lower(),
-                    class_name=class_name,
                     debugging=DEBUGGING,
                 )
                 try:

--- a/fetch_subscription_resources.py
+++ b/fetch_subscription_resources.py
@@ -532,7 +532,7 @@ def iterate_resources_to_json(
             try:
                 hva_tag = tags["scad"]
                 hva_tags = hva_tagging.handle_hva_tag(
-                    hva_tag=hva_tag, resource_id=resource_id
+                    hva_tag=hva_tag, resource_id=resource_id, debugging=DEBUGGING
                 )
                 try:
                     json_representation["hva_tags"].append(hva_tags.__dict__)

--- a/fetch_subscription_resources.py
+++ b/fetch_subscription_resources.py
@@ -531,8 +531,12 @@ def iterate_resources_to_json(
                 json_key = "apiManagements"
             try:
                 hva_tag = tags["scad"]
+                class_name = json_key[0].upper() + json_key[1:-1]
                 hva_tags = hva_tagging.handle_hva_tag(
-                    hva_tag=hva_tag, resource_id=resource_id, debugging=DEBUGGING
+                    hva_tag=hva_tag,
+                    resource_id=resource_id.lower(),
+                    class_name=class_name,
+                    debugging=DEBUGGING,
                 )
                 try:
                     json_representation["hva_tags"].append(hva_tags.__dict__)

--- a/fetch_subscription_resources.py
+++ b/fetch_subscription_resources.py
@@ -837,13 +837,6 @@ def write_ad_as_json():
         # Don't want to include application insights in standard environment parsing (should be optional to enrich model)
         del final_json_object["applicationInsights"]
     # print(json.dumps(obj=final_json_object, indent=4, sort_keys=True))
-    try:
-        print(
-            "Final obj:",
-            final_json_object["hva_tagging"],
-        )
-    except KeyError:
-        pass
     with open(
         os.path.join(BASE_DIR, f"environment_files/active_directory_{timestamp}.json"),
         "w",

--- a/schema_classes.py
+++ b/schema_classes.py
@@ -781,8 +781,16 @@ class Group:
 
 
 class HVA_Tag:
-    def __init__(self, resourceId, confValue, integrityValue, availValue) -> None:
-        self.id = resourceId
-        self.confValue = confValue
-        self.integrityValue = integrityValue
-        self.availValue = availValue
+    def __init__(
+        self: str,
+        resourceId: str,
+        className: str,
+        confValue: str,
+        integrityValue: str,
+        availValue: str,
+    ) -> None:
+        self.id: str = resourceId
+        self.className: str = className
+        self.confValue: str = confValue
+        self.integrityValue: str = integrityValue
+        self.availValue: str = availValue

--- a/schema_classes.py
+++ b/schema_classes.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class Subscription:
     def __init__(self, resourceId, name, subscriptionId, authorizationSource):
         """Required: \n
@@ -146,9 +147,17 @@ class VnetGateway:
         self.capacity = capacity
         self.provider = provider
 
+
 class LocalNetworkGateway:
     def __init__(
-        self, gwId, name, resourceGroup, localNetworkAddressSpace, gatewayIp, provider, bgpSettings
+        self,
+        gwId,
+        name,
+        resourceGroup,
+        localNetworkAddressSpace,
+        gatewayIp,
+        provider,
+        bgpSettings,
     ):
         self.id = gwId
         self.name = name
@@ -157,6 +166,7 @@ class LocalNetworkGateway:
         self.gatewayIp = gatewayIp
         self.provider = provider
         self.bgpSettings = bgpSettings
+
 
 class Connection:
     def __init__(
@@ -379,7 +389,14 @@ class Subnet:
 
 class Vnet:
     def __init__(
-        self, resourceId, name, resourceGroup, addressSpace, subnets, provider, vnetPeerings
+        self,
+        resourceId,
+        name,
+        resourceGroup,
+        addressSpace,
+        subnets,
+        provider,
+        vnetPeerings,
     ):
         """Required: \n
         resourceId, name, resourceGroup, addressSpace, subnets
@@ -521,7 +538,7 @@ class AppService:
         self.provider = provider
         self.principalId = principalId
         self.principalType = principalType
-        self.userAssignedIdentities=userAssignedIdentities
+        self.userAssignedIdentities = userAssignedIdentities
         self.kind = kind
         self.privateEndpoints = privateEndpoints
         self.outboundAddresses = outboundAddresses
@@ -756,11 +773,16 @@ class APIManagement:
         self.apiManagementUsers = apiManagementUsers
         self.apiManagementSubscriptions = apiManagementSubscriptions
 
+
 class Group:
-    def __init__(
-        self,
-        groupId,
-        members
-    ):
+    def __init__(self, groupId, members):
         self.groupId = groupId
         self.members = members
+
+
+class HVA_Tag:
+    def __init__(self, assetId, confValue, integrityValue, availValue) -> None:
+        self.assetId = assetId
+        self.confValue = confValue
+        self.integrityValue = integrityValue
+        self.availValue = availValue

--- a/schema_classes.py
+++ b/schema_classes.py
@@ -784,13 +784,11 @@ class HVA_Tag:
     def __init__(
         self: str,
         resourceId: str,
-        className: str,
         confValue: int,
         integrityValue: int,
         availValue: int,
     ) -> None:
         self.id: str = resourceId
-        self.className: str = className
         self.confValue: int = confValue
         self.integrityValue: int = integrityValue
         self.availValue: int = availValue

--- a/schema_classes.py
+++ b/schema_classes.py
@@ -785,12 +785,12 @@ class HVA_Tag:
         self: str,
         resourceId: str,
         className: str,
-        confValue: str,
-        integrityValue: str,
-        availValue: str,
+        confValue: int,
+        integrityValue: int,
+        availValue: int,
     ) -> None:
         self.id: str = resourceId
         self.className: str = className
-        self.confValue: str = confValue
-        self.integrityValue: str = integrityValue
-        self.availValue: str = availValue
+        self.confValue: int = confValue
+        self.integrityValue: int = integrityValue
+        self.availValue: int = availValue

--- a/schema_classes.py
+++ b/schema_classes.py
@@ -781,8 +781,8 @@ class Group:
 
 
 class HVA_Tag:
-    def __init__(self, assetId, confValue, integrityValue, availValue) -> None:
-        self.assetId = assetId
+    def __init__(self, resourceId, confValue, integrityValue, availValue) -> None:
+        self.id = resourceId
         self.confValue = confValue
         self.integrityValue = integrityValue
         self.availValue = availValue

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -5,31 +5,31 @@ def handle_hva_tag(
     hva_tag: str, resource_id: str, class_name: str, debugging: bool
 ) -> HVA_Tag:
     components = hva_tag.split(",")
-    c_val, i_val, a_val = "0", "0", "0"
+    c_val, i_val, a_val = 0, 0, 0
     for component in components:
         try:
             string = component.split(":")
             category = string[0]
-            number = string[1]
             try:
-                if int(number) > 10:
-                    if debugging:
-                        print(
-                            f"HVA consequence cannot be above 10, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 10."
-                        )
-                    number = "10"
-                elif int(number) < 0:
-                    if debugging:
-                        print(
-                            f"HVA consequence cannot be below 0, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 0."
-                        )
-                    number = "0"
+                number = int(string[1])
             except ValueError:
                 if debugging:
                     print(
-                        f"HVA value '{number}' for resource '{resource_id}' should be numeric but isn't. Skipping assignment."
+                        f"HVA value '{string[1]}' for resource '{resource_id}' should be numeric but isn't. Skipping assignment."
                     )
                     continue
+            if number > 10:
+                if debugging:
+                    print(
+                        f"HVA consequence cannot be above 10, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 10."
+                    )
+                number = 10
+            elif number < 0:
+                if debugging:
+                    print(
+                        f"HVA consequence cannot be below 0, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 0."
+                    )
+                number = 0
             if category.lower() == "c":
                 c_val = number
             elif category.lower() == "i":

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -1,8 +1,9 @@
-from typing import Dict
 from schema_classes import HVA_Tag
 
 
-def handle_hva_tag(hva_tag: str, resource_id: str, debugging: bool) -> Dict[str, str]:
+def handle_hva_tag(
+    hva_tag: str, resource_id: str, class_name: str, debugging: bool
+) -> HVA_Tag:
     components = hva_tag.split(",")
     c_val, i_val, a_val = "0", "0", "0"
     for component in components:
@@ -11,16 +12,22 @@ def handle_hva_tag(hva_tag: str, resource_id: str, debugging: bool) -> Dict[str,
             category = string[0]
             number = string[1]
             try:
-                if int(number) > 10 or int(number) < 0:
+                if int(number) > 10:
                     if debugging:
                         print(
-                            f"HVA value '{number}' for resource '{resource_id}' is incorrect. Should be a number between 0 and 10."
+                            f"HVA consequence cannot be above 10, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 10."
                         )
-                        continue
-            except ValueError as e:
+                    number = "10"
+                elif int(number) < 0:
+                    if debugging:
+                        print(
+                            f"HVA consequence cannot be below 0, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 0."
+                        )
+                    number = "0"
+            except ValueError:
                 if debugging:
                     print(
-                        f"HVA value '{number}' for resource '{resource_id}' should be numeric but isn't."
+                        f"HVA value '{number}' for resource '{resource_id}' should be numeric but isn't. Skipping assignment."
                     )
                     continue
             if category.lower() == "c":
@@ -37,10 +44,11 @@ def handle_hva_tag(hva_tag: str, resource_id: str, debugging: bool) -> Dict[str,
         except IndexError:
             if debugging:
                 print(
-                    f"Parsing HVA tag {component} resulted in index error. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
+                    f"Parsing HVA tag {component} resulted in IndexError. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
                 )
     return HVA_Tag(
         resourceId=resource_id,
+        className=class_name,
         confValue=c_val,
         integrityValue=i_val,
         availValue=a_val,

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -1,0 +1,21 @@
+from typing import Dict
+from schema_classes import HVA_Tag
+
+
+def handle_hva_tag(
+    hva_tag: str,
+    resource_id: str,
+) -> Dict[str, str]:
+    values = hva_tag.split(",")
+    c_val = values[0].split(":")[1]
+    i_val = values[1].split(":")[1]
+    a_val = values[2].split(":")[1]
+    if c_val or i_val or a_val:
+        return HVA_Tag(
+            resourceId=resource_id,
+            confValue=c_val,
+            integrityValue=i_val,
+            availValue=a_val,
+        )
+    else:
+        return None

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -3,21 +3,41 @@ from schema_classes import HVA_Tag
 
 
 def handle_hva_tag(hva_tag: str, resource_id: str, debugging: bool) -> Dict[str, str]:
-    values = hva_tag.split(",")
+    components = hva_tag.split(",")
     c_val, i_val, a_val = "0", "0", "0"
-    for val in values:
-        value = val.split(":")
-        category = value[0]
-        if category.lower() == "c":
-            c_val = value[1]
-        elif category.lower() == "i":
-            i_val = value[1]
-        elif category.lower() == "a":
-            a_val = value[1]
-        else:
+    for component in components:
+        try:
+            string = component.split(":")
+            category = string[0]
+            number = string[1]
+            try:
+                if int(number) > 10 or int(number) < 0:
+                    if debugging:
+                        print(
+                            f"HVA value '{number}' for resource '{resource_id}' is incorrect. Should be a number between 0 and 10."
+                        )
+                        continue
+            except ValueError as e:
+                if debugging:
+                    print(
+                        f"HVA value '{number}' for resource '{resource_id}' should be numeric but isn't."
+                    )
+                    continue
+            if category.lower() == "c":
+                c_val = number
+            elif category.lower() == "i":
+                i_val = number
+            elif category.lower() == "a":
+                a_val = number
+            else:
+                if debugging:
+                    print(
+                        f"Incorrectly formatted HVA tag: {hva_tag}. Valid prefixes are only c, i or a (case-insensitive)."
+                    )
+        except IndexError:
             if debugging:
                 print(
-                    "Incorrect format on HVA tag. Format should be: 'c:n,i:n,a:n' where n is the corresponding Confidentiality, Integrity or Availability value for the asset, between 0 and 10."
+                    f"Parsing HVA tag {component} resulted in index error. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
                 )
     return HVA_Tag(
         resourceId=resource_id,

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -2,20 +2,26 @@ from typing import Dict
 from schema_classes import HVA_Tag
 
 
-def handle_hva_tag(
-    hva_tag: str,
-    resource_id: str,
-) -> Dict[str, str]:
+def handle_hva_tag(hva_tag: str, resource_id: str, debugging: bool) -> Dict[str, str]:
     values = hva_tag.split(",")
-    c_val = values[0].split(":")[1]
-    i_val = values[1].split(":")[1]
-    a_val = values[2].split(":")[1]
-    if c_val or i_val or a_val:
-        return HVA_Tag(
-            resourceId=resource_id,
-            confValue=c_val,
-            integrityValue=i_val,
-            availValue=a_val,
-        )
-    else:
-        return None
+    c_val, i_val, a_val = "0", "0", "0"
+    for val in values:
+        value = val.split(":")
+        category = value[0]
+        if category.lower() == "c":
+            c_val = value[1]
+        elif category.lower() == "i":
+            i_val = value[1]
+        elif category.lower() == "a":
+            a_val = value[1]
+        else:
+            if debugging:
+                print(
+                    "Incorrect format on HVA tag. Format should be: 'c:n,i:n,a:n' where n is the corresponding Confidentiality, Integrity or Availability value for the asset, between 0 and 10."
+                )
+    return HVA_Tag(
+        resourceId=resource_id,
+        confValue=c_val,
+        integrityValue=i_val,
+        availValue=a_val,
+    )

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -15,19 +15,19 @@ def handle_hva_tag(
             except ValueError:
                 if debugging:
                     print(
-                        f"HVA value '{string[1]}' for resource '{resource_id}' should be numeric but isn't. Skipping assignment."
+                        f"ERROR: HVA value '{string[1]}' for resource '{resource_id}' should be numeric but isn't. Skipping assignment."
                     )
                     continue
             if number > 10:
                 if debugging:
                     print(
-                        f"HVA consequence cannot be above 10, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 10."
+                        f"ERROR: HVA consequence cannot be above 10, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 10."
                     )
                 number = 10
             elif number < 0:
                 if debugging:
                     print(
-                        f"HVA consequence cannot be below 0, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 0."
+                        f"ERROR: HVA consequence cannot be below 0, but resource '{resource_id}' is assigned {number}. Defaulting consequence to 0."
                     )
                 number = 0
             if category.lower() == "c":
@@ -39,12 +39,13 @@ def handle_hva_tag(
             else:
                 if debugging:
                     print(
-                        f"Incorrectly formatted HVA tag: {hva_tag}. Valid prefixes are only c, i or a (case-insensitive)."
+                        f"ERROR: Incorrectly formatted HVA tag: {hva_tag}. Valid prefixes are only c, i or a (case-insensitive)."
                     )
-        except IndexError:
+        except IndexError as e:
             if debugging:
                 print(
-                    f"Parsing HVA tag {component} resulted in IndexError. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
+                    f"WARNING: Parsing HVA tag {component} resulted in IndexError. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
+                    + e
                 )
     return HVA_Tag(
         resourceId=resource_id,

--- a/services/hva_tagging.py
+++ b/services/hva_tagging.py
@@ -44,8 +44,7 @@ def handle_hva_tag(
         except IndexError as e:
             if debugging:
                 print(
-                    f"WARNING: Parsing HVA tag {component} resulted in IndexError. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma."
-                    + e
+                    f"WARNING: Parsing HVA tag {component} resulted in IndexError. Make sure each pair is formatted as 'prefix:suffix' and separated by a comma. \n Error message: {e}"
                 )
     return HVA_Tag(
         resourceId=resource_id,


### PR DESCRIPTION
Adds support for reading certain tags on azure resource objects, making them into HVA_Tag objects, and adding them to the ad.json output file. 

Resource tag should be formatted as 'C:1,I:2,A:3', with the numbers being the corresponding confidentiality, integrity and availability value for the given resource (with 0 being the lowest and 10 the highest). 

Tag is case- and order-insensitive, and not all three need to be present (if one is absent, its value defaults to 0). So e.g. 'i:3,A:9', 'a:10', or 'a:0,i:9,c:5' are all valid tags.